### PR TITLE
Add EIS Swot Team to VEDA

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -47,6 +47,7 @@ basehub:
             - CYGNSS-VEDA:cygnss-iwg
             - veda-analytics-access:maap-biomass-team
             - Earth-Information-System:eis-fire
+            - Earth-Information-System:swot
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
Onboard the EIS Swot team to the VEDAhub instance the same way EIS Fire already has access so that EIS Owners can manage specific users.

https://github.com/NASA-IMPACT/veda-analytics/issues/103