### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: readthedocs/actions/preview@v1
+    - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1
       with:
           # The project slug in RTD still has the old repo name
         project-slug: 2i2c-pilot-hubs

--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -39,14 +39,14 @@ jobs:
       # Action: https://github.com/marketplace/actions/github-app-token
     - name: Fetch a token from GitHub App
       id: generate_token
-      uses: tibdex/github-app-token@v2
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
       with:
         app_id: ${{ secrets.APP_ID }}
         private_key: ${{ secrets.PRIVATE_KEY }}
 
       # Action repo: https://github.com/sgibson91/bump-helm-deps-action
     - name: 'Bump helm chart versions: ${{ matrix.name }}'
-      uses: sgibson91/bump-helm-deps-action@main
+      uses: sgibson91/bump-helm-deps-action@2b113b02a37e511aa51ab8a329b6736086ccc0bb # main
       with:
         chart_path: ${{ matrix.chart_path }}
         chart_urls: ${{ matrix.chart_urls }}

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -47,14 +47,14 @@ jobs:
       # Action: https://github.com/marketplace/actions/github-app-token
     - name: Fetch a token from GitHub App
       id: generate_token
-      uses: tibdex/github-app-token@v2
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
       with:
         app_id: ${{ secrets.APP_ID }}
         private_key: ${{ secrets.PRIVATE_KEY }}
 
       # Action repo: https://github.com/sgibson91/bump-jhub-image-action
     - name: 'Bump image tags: ${{ matrix.name }}'
-      uses: sgibson91/bump-jhub-image-action@main
+      uses: sgibson91/bump-jhub-image-action@e3327db064478c85192f793c8da84ed1b19dc806 # main
       with:
         config_path: ${{ matrix.config_path }}
         images_info: ${{ matrix.images_info }}

--- a/.github/workflows/comment-dependabot-prs.yaml
+++ b/.github/workflows/comment-dependabot-prs.yaml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Add comment
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
       with:
         issue-number: ${{ github.event.number }}
         body: |

--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -32,7 +32,7 @@ jobs:
       issues: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - run: pip install requests
     - run: python extra-scripts/comment-deployment-plan-pr.py
       env:

--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -33,7 +33,7 @@ jobs:
       actions: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - run: pip install requests
     - run: python extra-scripts/comment-test-link-merged-pr.py
       env:

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -56,9 +56,9 @@ jobs:
         - cluster_name: heliophysics
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.13'
 
@@ -73,10 +73,10 @@ jobs:
             | tar -xvz --one-top-level=$HOME/.local/bin
 
     - name: Install sops
-      uses: mdgreenwald/mozilla-sops-action@v1.6.0
+      uses: mdgreenwald/mozilla-sops-action@d9714e521cbaecdae64a89d2fdd576dd2aa97056 # v1.6.0
 
     - name: Setup sops credentials to decrypt repo secrets
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
       with:
         credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
 


### PR DESCRIPTION
## Pin GitHub Actions to SHA digests

Zizmor detected **58** `unpinned-uses` findings in `.github/workflows/`.

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) are vulnerable to tag mutation — a compromised or hijacked tag can introduce malicious code into CI runs. Pinning to a full commit SHA (e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4`) eliminates this supply-chain risk.

This PR pins all workflow steps to their current SHA using [`pin-github-action`](https://github.com/mheap/pin-github-action), fixing 58 findings.

### Recommended next steps

1. Enable Dependabot for `github-actions` to keep pinned SHAs up-to-date automatically (a companion PR will be opened for this repo).
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

### References

- [zizmor unpinned-uses audit](https://docs.zizmor.sh/audits/#unpinned-uses)
- [pin-github-action](https://github.com/mheap/pin-github-action)

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_